### PR TITLE
link to the ACH (rather than Fedwire) format page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 If you are reading this, you probably have interviewed or chatted with someone on the team at Zipmark.  This is our standard "toy" project we normally like to work on together to see how you think about problems, model them, and make decisions.  If you stumbled upon this project randomly and want to give it a shot, please feel free to fork the project and hack away.  We would love to see what you come up with.
 
-An initial version of this project should be doable in a short amount of time (we usually do coding sessions for less than half a day with interviewees), but has many facets that could be improved beyond that inital cut. 
+An initial version of this project should be doable in a short amount of time (we usually do coding sessions for less than half a day with interviewees), but has many facets that could be improved beyond that inital cut.
 
 ## Objective
 
@@ -10,7 +10,7 @@ Build a small application that fetches and updates the Federal Reserve's current
 
 ## Resources
 
-* [Fedwire Directory File Format](https://www.frbservices.org/EPaymentsDirectory/fedwireFormat.html)
+* [Fedwire Directory File Format](https://www.frbservices.org/EPaymentsDirectory/achFormat.html)
   * Provides the "rules" for how the bank routing number data file is formatted
 
 * [Bank Data](https://www.frbservices.org/EPaymentsDirectory/FedACHdir.txt)
@@ -32,7 +32,7 @@ Build a small application that fetches and updates the Federal Reserve's current
 
 `curl http://hostname/banks/123456789`
 
-Output: 
+Output:
 
 ```json
 {


### PR DESCRIPTION
The file format link added in the recent readme update included the Fedwire format style rather than the ACH format table.